### PR TITLE
Removed StatusBar from Root

### DIFF
--- a/packages/expo-router/src/ExpoRoot.tsx
+++ b/packages/expo-router/src/ExpoRoot.tsx
@@ -45,11 +45,6 @@ const INITIAL_METRICS = {
   insets: { top: 0, left: 0, right: 0, bottom: 0 },
 };
 
-const hasViewControllerBasedStatusBarAppearance =
-  Platform.OS === "ios" &&
-  !!Constants.expoConfig?.ios?.infoPlist
-    ?.UIViewControllerBasedStatusBarAppearance;
-
 export function ExpoRoot({
   wrapper: ParentWrapper = Fragment,
   ...props
@@ -68,11 +63,6 @@ export function ExpoRoot({
             initialMetrics={INITIAL_METRICS}
           >
             {children}
-
-            {/* Users can override this by adding another StatusBar element anywhere higher in the component tree. */}
-            {!hasViewControllerBasedStatusBarAppearance && (
-              <StatusBar style="auto" />
-            )}
           </SafeAreaProvider>
         </GestureHandlerRootView>
       </ParentWrapper>


### PR DESCRIPTION
# Motivation

This code causes StatusBar components to be overwritten in multiple scenarios and cause flicker if userInterfaceStyle is dark and statusbar should be light and vice versa.

# Execution

By removing the StatusBar component from the Root.

# Test Plan

Have an app with userInterfaceStyle set to dark. Place a StatusBar component in the _layout root set to dark. Without this PR the status bar is light, but with this PR status bar is dark.